### PR TITLE
Show Paragraphs on Landing page

### DIFF
--- a/Application/Schema.sql
+++ b/Application/Schema.sql
@@ -17,7 +17,8 @@ CREATE TRIGGER update_landing_pages_updated_at BEFORE UPDATE ON landing_pages FO
 CREATE TABLE paragraph_quotes (
     id UUID DEFAULT uuid_generate_v4() PRIMARY KEY NOT NULL,
     landing_page_id UUID NOT NULL,
-    weight INT DEFAULT 0 NOT NULL
+    weight INT DEFAULT 0 NOT NULL,
+    title TEXT NOT NULL
 );
 CREATE TABLE paragraph_ctas (
     id UUID DEFAULT uuid_generate_v4() PRIMARY KEY NOT NULL,

--- a/Web/Controller/LandingPages.hs
+++ b/Web/Controller/LandingPages.hs
@@ -37,6 +37,7 @@ instance Controller LandingPagesController where
         where
             -- We will render each paragraph with it's own renderer, and have a tuple
             -- with the weight, and the `hsx` result. Then we can sort the list by weight.
+            -- @todo: Why do we need to type hint the paragraph?
             paragraphCtas' = paragraphCtas
                     |> fmap (\(paragraph :: ParagraphCta) -> (paragraph.weight, ParagraphCtas.renderParagraph paragraph.title))
 
@@ -46,10 +47,9 @@ instance Controller LandingPagesController where
             -- @todo: Is there a better way, so render happens inside the Show instead of here.
             -- Currently without rendering, we can't place all in a single List, as they have different
             -- types.
-
-            -- allParagraphsRendered = paragraphCtas' ++ paragraphQuotes'
+            allParagraphsRendered = merge paragraphCtas' paragraphQuotes'
                 -- Sort the paragraphs by weight.
-                -- |> sortOn fst
+                -- |> sort
                 -- Get the `hsx` result.
                 -- |> fmap snd
 
@@ -89,5 +89,8 @@ instance Controller LandingPagesController where
 buildLandingPage landingPage = landingPage
     |> fill @'["title", "slug"]
 
-merge [] ys = ys
-merge (x:xs) ys = x:merge ys xs
+-- https://stackoverflow.com/a/70335119/750039
+merge :: [a] -> [a] -> [a]
+merge xs     []     = xs
+merge []     ys     = ys
+merge (x:xs) (y:ys) = x : y : merge xs ys

--- a/Web/View/LandingPages/Show.hs
+++ b/Web/View/LandingPages/Show.hs
@@ -1,7 +1,11 @@
 module Web.View.LandingPages.Show where
 import Web.View.Prelude
+import Text.Blaze.Html
 
-data ShowView = ShowView { landingPage :: LandingPage }
+data ShowView = ShowView
+    {   landingPage :: LandingPage
+    -- ,   allParagraphsRendered :: [Text.Blaze.Html.Html]
+    }
 
 instance View ShowView where
     html ShowView { .. } = [hsx|
@@ -10,7 +14,7 @@ instance View ShowView where
             <h1 class="text-3xl">{landingPage.title}</h1>
             <a href={EditLandingPageAction landingPage.id} class="text-blue-500 text-sm hover:underline hover:text-blue-600">(Edit)</a>
         </div>
-        <p></p>
+        <!-- {allParagraphsRendered} -->
 
     |]
         where

--- a/Web/View/ParagraphCtas/Index.hs
+++ b/Web/View/ParagraphCtas/Index.hs
@@ -31,7 +31,7 @@ instance View IndexView where
 renderParagraphCta :: ParagraphCta -> Html
 renderParagraphCta paragraphCta = [hsx|
     <tr>
-        <td>{paragraphCta}</td>
+        <td>{paragraphCta.title}</td>
         <td><a href={ShowParagraphCtaAction paragraphCta.id}>Show</a></td>
         <td><a href={EditParagraphCtaAction paragraphCta.id} class="text-muted">Edit</a></td>
         <td><a href={DeleteParagraphCtaAction paragraphCta.id} class="js-delete text-muted">Delete</a></td>

--- a/Web/View/ParagraphCtas/Show.hs
+++ b/Web/View/ParagraphCtas/Show.hs
@@ -15,3 +15,13 @@ instance View ShowView where
                             [ breadcrumbLink "ParagraphCta" ParagraphCtaAction
                             , breadcrumbText "Show ParagraphCta"
                             ]
+
+
+
+renderParagraph :: Text -> Html
+renderParagraph title =
+    [hsx|
+    <div>
+        <h1 class="text-3xl font-bold">CTA: {title}</h1>
+    </div>
+    |]

--- a/Web/View/ParagraphQuotes/Index.hs
+++ b/Web/View/ParagraphQuotes/Index.hs
@@ -20,7 +20,7 @@ instance View IndexView where
                 </thead>
                 <tbody>{forEach paragraphQuotes renderParagraphQuote}</tbody>
             </table>
-            
+
         </div>
     |]
         where
@@ -31,7 +31,7 @@ instance View IndexView where
 renderParagraphQuote :: ParagraphQuote -> Html
 renderParagraphQuote paragraphQuote = [hsx|
     <tr>
-        <td>{paragraphQuote}</td>
+        <td>{paragraphQuote.title}</td>
         <td><a href={ShowParagraphQuoteAction paragraphQuote.id}>Show</a></td>
         <td><a href={EditParagraphQuoteAction paragraphQuote.id} class="text-muted">Edit</a></td>
         <td><a href={DeleteParagraphQuoteAction paragraphQuote.id} class="js-delete text-muted">Delete</a></td>

--- a/Web/View/ParagraphQuotes/Show.hs
+++ b/Web/View/ParagraphQuotes/Show.hs
@@ -15,3 +15,11 @@ instance View ShowView where
                             [ breadcrumbLink "ParagraphQuotes" ParagraphQuotesAction
                             , breadcrumbText "Show ParagraphQuote"
                             ]
+
+renderParagraph :: Text -> Html
+renderParagraph title =
+    [hsx|
+    <div>
+        <h1 class="text-3xl font-bold">Quote: {title}</h1>
+    </div>
+    |]


### PR DESCRIPTION
I am experimenting with creating a Landing page with different Paragraphs. Those terms are from our Drupal starter kit, and look like this (there's the "node" view and the node edit page). Very handy for our content editors, that get the freedom to mix & match different structured content)

| Drupal's Node view | Drupal's Node edit | 
| -- | -- |
| ![image](https://github.com/amitaibu/ihp-landing-page/assets/125707/0cf0d20a-c6b6-4e0b-b60a-d839f8c44e1c) | ![image](https://github.com/amitaibu/ihp-landing-page/assets/125707/77bf2799-736c-4798-bbe9-d42fc4cd48f9) |

We have multiple paragraph types. Every landing page will have a few. 

1. We can query each paragraph, since there aren't many. But maybe there's a nicer way
2. I'd like to pass along to LandingPage.View a list with [(paragraph weight, Paragraph type (e.g. `ParagraphCta` or `ParagraphQuote`). And then on the LandingPage.View call the correct renderer. Not sure what's the right way to do it. Compiler doesn't like my different attempts.
