### PR TITLE
Sortable not working if navigating from another page

### DIFF
--- a/static/sortable.js
+++ b/static/sortable.js
@@ -1,4 +1,7 @@
+console.log('Sortable outside onReady');
 $(document).on('ready turbolinks:load', function () {
+
+    console.log('OK: Sortable inside onReady');
 
     // Init sortable.
     document.querySelectorAll('.js-sortable').forEach(function (elem) {


### PR DESCRIPTION
1. Get this debug branch and open dev console
1. Add a Landing page and a few CTA/ Qutes "paragraphs"
2. Go to the "Show" page
3. Refresh browser (f5) on the Show page.
4. Now click on the Edit link, and try to sort. The `OK: Sortable inside onReady` isn't triggered.

![image](https://github.com/amitaibu/ihp-landing-page/assets/125707/662b9d20-4de7-418b-8b75-e0883b15196b)


