### PR TITLE
Example to redirectToUrl doesn't work with hash

### DIFF
--- a/Web/Controller/LandingPages.hs
+++ b/Web/Controller/LandingPages.hs
@@ -93,9 +93,10 @@ instance Controller LandingPagesController where
                 Left landingPage -> render NewView { .. }
                 Right landingPage -> do
                     landingPage <- landingPage |> createRecord
+                    let landingPageId = landingPage.id
                     setSuccessMessage "LandingPage created"
-                    -- After we create the Landing page, we can start adding Paragraphs to it.
-                    redirectTo EditLandingPageAction { landingPageId = landingPage.id }
+                    -- Redirect back to the index page.
+                    redirectToUrl $ urlTo LandingPagesAction ++ "#" ++ show landingPageId
 
     action DeleteLandingPageAction { landingPageId } = do
         landingPage <- fetch landingPageId

--- a/Web/View/LandingPages/Index.hs
+++ b/Web/View/LandingPages/Index.hs
@@ -32,7 +32,9 @@ instance View IndexView where
 
 renderLandingPage :: LandingPage -> Html
 renderLandingPage landingPage = [hsx|
-    {body}
+    <div id={landingPage.id}>
+        {body}
+    </div>
 |]
     where
         body =


### PR DESCRIPTION
1. Grab PR
2. Create a new "Landing page"
3. You should be redirected with `http://localhost:8000/LandingPages#[uuid-of-create-lp]` - however you are redirected to `http://localhost:8000/LandingPages`. The hash is missing